### PR TITLE
Remove LiveInternet counter fragments breaking React rendering

### DIFF
--- a/client/src/pages/ClubDetail.js
+++ b/client/src/pages/ClubDetail.js
@@ -175,16 +175,6 @@ const ClubDetail = () => {
             </div>
           )}
         </div>
-<!--LiveInternet counter--><a href="https://www.liveinternet.ru/click"
-target="_blank"><img id="licntD8A3" width="88" height="31" style="border:0" 
-title="LiveInternet: показано число просмотров и посетителей за 24 часа"
-src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAEALAAAAAABAAEAAAIBTAA7"
-alt=""/></a><script>(function(d,s){d.getElementById("licntD8A3").src=
-"https://counter.yadro.ru/hit?t53.11;r"+escape(d.referrer)+
-((typeof(s)=="undefined")?"":";s"+s.width+"*"+s.height+"*"+
-(s.colorDepth?s.colorDepth:s.pixelDepth))+";u"+escape(d.URL)+
-";h"+escape(d.title.substring(0,150))+";"+Math.random()})
-(document,screen)</script><!--/LiveInternet-->
 
         {/* News Wall Section */}
         {user && isUserMember() && (

--- a/client/src/pages/Clubs.js
+++ b/client/src/pages/Clubs.js
@@ -116,17 +116,6 @@ const Clubs = () => {
         </div>
       </section>
     </div>
-<!--LiveInternet counter--><a href="https://www.liveinternet.ru/click"
-target="_blank"><img id="licntD8A3" width="88" height="31" style="border:0" 
-title="LiveInternet: показано число просмотров и посетителей за 24 часа"
-src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAEALAAAAAABAAEAAAIBTAA7"
-alt=""/></a><script>(function(d,s){d.getElementById("licntD8A3").src=
-"https://counter.yadro.ru/hit?t53.11;r"+escape(d.referrer)+
-((typeof(s)=="undefined")?"":";s"+s.width+"*"+s.height+"*"+
-(s.colorDepth?s.colorDepth:s.pixelDepth))+";u"+escape(d.URL)+
-";h"+escape(d.title.substring(0,150))+";"+Math.random()})
-(document,screen)</script><!--/LiveInternet-->
-
   );
 };
 

--- a/client/src/pages/CreateClub.js
+++ b/client/src/pages/CreateClub.js
@@ -167,17 +167,6 @@ const CreateClub = () => {
         </div>
       </div>
     </div>
-<!--LiveInternet counter--><a href="https://www.liveinternet.ru/click"
-target="_blank"><img id="licntD8A3" width="88" height="31" style="border:0" 
-title="LiveInternet: показано число просмотров и посетителей за 24 часа"
-src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAEALAAAAAABAAEAAAIBTAA7"
-alt=""/></a><script>(function(d,s){d.getElementById("licntD8A3").src=
-"https://counter.yadro.ru/hit?t53.11;r"+escape(d.referrer)+
-((typeof(s)=="undefined")?"":";s"+s.width+"*"+s.height+"*"+
-(s.colorDepth?s.colorDepth:s.pixelDepth))+";u"+escape(d.URL)+
-";h"+escape(d.title.substring(0,150))+";"+Math.random()})
-(document,screen)</script><!--/LiveInternet-->
-
   );
 };
 

--- a/client/src/pages/EditClub.js
+++ b/client/src/pages/EditClub.js
@@ -220,17 +220,6 @@ const EditClub = () => {
         </div>
       </div>
     </div>
-<!--LiveInternet counter--><a href="https://www.liveinternet.ru/click"
-target="_blank"><img id="licntD8A3" width="88" height="31" style="border:0" 
-title="LiveInternet: показано число просмотров и посетителей за 24 часа"
-src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAEALAAAAAABAAEAAAIBTAA7"
-alt=""/></a><script>(function(d,s){d.getElementById("licntD8A3").src=
-"https://counter.yadro.ru/hit?t53.11;r"+escape(d.referrer)+
-((typeof(s)=="undefined")?"":";s"+s.width+"*"+s.height+"*"+
-(s.colorDepth?s.colorDepth:s.pixelDepth))+";u"+escape(d.URL)+
-";h"+escape(d.title.substring(0,150))+";"+Math.random()})
-(document,screen)</script><!--/LiveInternet-->
-
   );
 };
 

--- a/client/src/pages/Home.js
+++ b/client/src/pages/Home.js
@@ -91,17 +91,6 @@ const Home = () => {
         </div>
       </section>
     </div>
-<!--LiveInternet counter--><a href="https://www.liveinternet.ru/click"
-target="_blank"><img id="licntD8A3" width="88" height="31" style="border:0" 
-title="LiveInternet: показано число просмотров и посетителей за 24 часа"
-src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAEALAAAAAABAAEAAAIBTAA7"
-alt=""/></a><script>(function(d,s){d.getElementById("licntD8A3").src=
-"https://counter.yadro.ru/hit?t53.11;r"+escape(d.referrer)+
-((typeof(s)=="undefined")?"":";s"+s.width+"*"+s.height+"*"+
-(s.colorDepth?s.colorDepth:s.pixelDepth))+";u"+escape(d.URL)+
-";h"+escape(d.title.substring(0,150))+";"+Math.random()})
-(document,screen)</script><!--/LiveInternet-->
-
   );
 };
 

--- a/client/src/pages/Login.js
+++ b/client/src/pages/Login.js
@@ -94,17 +94,6 @@ const Login = () => {
       </div>
     </div>
   );
-<!--LiveInternet counter--><a href="https://www.liveinternet.ru/click"
-target="_blank"><img id="licntD8A3" width="88" height="31" style="border:0" 
-title="LiveInternet: показано число просмотров и посетителей за 24 часа"
-src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAEALAAAAAABAAEAAAIBTAA7"
-alt=""/></a><script>(function(d,s){d.getElementById("licntD8A3").src=
-"https://counter.yadro.ru/hit?t53.11;r"+escape(d.referrer)+
-((typeof(s)=="undefined")?"":";s"+s.width+"*"+s.height+"*"+
-(s.colorDepth?s.colorDepth:s.pixelDepth))+";u"+escape(d.URL)+
-";h"+escape(d.title.substring(0,150))+";"+Math.random()})
-(document,screen)</script><!--/LiveInternet-->
-
 };
 
 export default Login;

--- a/client/src/pages/Profile.js
+++ b/client/src/pages/Profile.js
@@ -124,17 +124,6 @@ const Profile = () => {
       </div>
     </div>
   );
-<!--LiveInternet counter--><a href="https://www.liveinternet.ru/click"
-target="_blank"><img id="licntD8A3" width="88" height="31" style="border:0" 
-title="LiveInternet: показано число просмотров и посетителей за 24 часа"
-src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAEALAAAAAABAAEAAAIBTAA7"
-alt=""/></a><script>(function(d,s){d.getElementById("licntD8A3").src=
-"https://counter.yadro.ru/hit?t53.11;r"+escape(d.referrer)+
-((typeof(s)=="undefined")?"":";s"+s.width+"*"+s.height+"*"+
-(s.colorDepth?s.colorDepth:s.pixelDepth))+";u"+escape(d.URL)+
-";h"+escape(d.title.substring(0,150))+";"+Math.random()})
-(document,screen)</script><!--/LiveInternet-->
-
 };
 
 export default Profile;

--- a/client/src/pages/Register.js
+++ b/client/src/pages/Register.js
@@ -138,17 +138,6 @@ const Register = () => {
       </div>
     </div>
   );
-<!--LiveInternet counter--><a href="https://www.liveinternet.ru/click"
-target="_blank"><img id="licntD8A3" width="88" height="31" style="border:0" 
-title="LiveInternet: показано число просмотров и посетителей за 24 часа"
-src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAEALAAAAAABAAEAAAIBTAA7"
-alt=""/></a><script>(function(d,s){d.getElementById("licntD8A3").src=
-"https://counter.yadro.ru/hit?t53.11;r"+escape(d.referrer)+
-((typeof(s)=="undefined")?"":";s"+s.width+"*"+s.height+"*"+
-(s.colorDepth?s.colorDepth:s.pixelDepth))+";u"+escape(d.URL)+
-";h"+escape(d.title.substring(0,150))+";"+Math.random()})
-(document,screen)</script><!--/LiveInternet-->
-
 };
 
 export default Register;


### PR DESCRIPTION
## Summary
- remove injected LiveInternet counter snippets that were inserted after component markup and broke JSX parsing
- ensure each page component now returns valid JSX without stray script tags that crash the client

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db93f63b348329a5f0d0976c3effe4