### PR TITLE
Configure axios base URL for client and update rewrites

### DIFF
--- a/client/src/components/NewsWall.js
+++ b/client/src/components/NewsWall.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useAuth } from '../context/AuthContext';
 import axios from 'axios';
+import API_BASE_URL from '../config/api';
 
 const NewsWall = ({ clubId }) => {
   const { user } = useAuth();
@@ -330,9 +331,9 @@ const NewsItem = ({ news, currentUser, onUpdate }) => {
         {news.images && news.images.length > 0 && (
           <div className="news-images">
             {news.images.map((image, index) => (
-              <img 
+              <img
                 key={index}
-                src={`http://localhost:5000/uploads/${image}`}
+                src={`${API_BASE_URL}/uploads/${image}`}
                 alt={`Изображение ${index + 1}`}
                 className="news-image"
               />

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -1,9 +1,13 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
+import axios from 'axios';
 import './index.css';
 import App from './App';
 import ErrorBoundary from './components/ErrorBoundary';
+import API_BASE_URL from './config/api';
+
+axios.defaults.baseURL = API_BASE_URL;
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(

--- a/client/vercel.json
+++ b/client/vercel.json
@@ -1,7 +1,7 @@
 {
   "rewrites": [
     {
-      "source": "/(.*)",
+      "source": "/((?!api(?:/|$)|_next/).*)",
       "destination": "/index.html"
     }
   ]


### PR DESCRIPTION
## Summary
- restrict the Vercel SPA rewrite so API and Next.js asset paths bypass index.html
- initialize Axios with the environment-specific API base URL for all client requests
- reuse the API base URL when rendering uploaded news images to avoid localhost links

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db988577248329bf3fbf9f1d86e143