### PR TITLE
feat: use static club data on public pages

### DIFF
--- a/client/src/data/clubs.js
+++ b/client/src/data/clubs.js
@@ -1,0 +1,100 @@
+const clubs = [
+  {
+    _id: '1',
+    name: 'IT Innovators',
+    description: 'Клуб, объединяющий студентов, интересующихся новыми технологиями, хакатонами и разработкой проектов.',
+    category: 'IT',
+    members: [
+      { _id: 'm1', name: 'Алексей Иванов', email: 'alexey@example.com' },
+      { _id: 'm2', name: 'Мария Смирнова', email: 'maria@example.com' },
+      { _id: 'm3', name: 'Кирилл Петров', email: 'kirill@example.com' }
+    ],
+    createdAt: '2023-01-15T10:00:00.000Z'
+  },
+  {
+    _id: '2',
+    name: 'Art & Culture Society',
+    description: 'Творческое объединение для любителей искусства, живописи, скульптуры и выставок.',
+    category: 'Культура',
+    members: [
+      { _id: 'm4', name: 'Елена Кузнецова', email: 'elena@example.com' },
+      { _id: 'm5', name: 'Игорь Соколов', email: 'igor@example.com' }
+    ],
+    createdAt: '2022-10-02T12:30:00.000Z'
+  },
+  {
+    _id: '3',
+    name: 'Green Planet',
+    description: 'Экологический клуб, продвигающий устойчивое развитие, переработку отходов и волонтёрские мероприятия.',
+    category: 'Творчество',
+    members: [
+      { _id: 'm6', name: 'Наталья Орлова', email: 'natalia@example.com' },
+      { _id: 'm7', name: 'Дмитрий Алексеев', email: 'dmitry@example.com' },
+      { _id: 'm8', name: 'Ольга Попова', email: 'olga@example.com' },
+      { _id: 'm9', name: 'Владислав Волков', email: 'vlad@example.com' }
+    ],
+    createdAt: '2021-05-20T08:15:00.000Z'
+  },
+  {
+    _id: '4',
+    name: 'Debate & Public Speaking',
+    description: 'Клуб для тех, кто хочет совершенствовать навыки публичных выступлений и аргументации.',
+    category: 'Развлечения',
+    members: [
+      { _id: 'm10', name: 'Светлана Фролова', email: 'svetlana@example.com' },
+      { _id: 'm11', name: 'Артём Николаев', email: 'artem@example.com' }
+    ],
+    createdAt: '2023-03-11T09:45:00.000Z'
+  },
+  {
+    _id: '5',
+    name: 'University Football Club',
+    description: 'Студенческая команда по футболу: тренировки, турнирные игры и спортивные сборы.',
+    category: 'Спорт',
+    members: [
+      { _id: 'm12', name: 'Илья Морозов', email: 'ilya@example.com' },
+      { _id: 'm13', name: 'Павел Захаров', email: 'pavel@example.com' },
+      { _id: 'm14', name: 'Сергей Антонов', email: 'sergey@example.com' },
+      { _id: 'm15', name: 'Анна Лебедева', email: 'anna@example.com' }
+    ],
+    createdAt: '2020-09-05T17:20:00.000Z'
+  },
+  {
+    _id: '6',
+    name: 'Photography Explorers',
+    description: 'Клуб фотографов-энтузиастов: мастер-классы, пленэры и конкурсные проекты.',
+    category: 'Творчество',
+    members: [
+      { _id: 'm16', name: 'Михаил Егорев', email: 'mikhail@example.com' },
+      { _id: 'm17', name: 'Вера Дмитриева', email: 'vera@example.com' },
+      { _id: 'm18', name: 'Егор Павлов', email: 'egor@example.com' }
+    ],
+    createdAt: '2022-01-22T14:10:00.000Z'
+  },
+  {
+    _id: '7',
+    name: 'Board Games League',
+    description: 'Клуб настольных игр: регулярные встречи, турниры и дружеские вечеринки.',
+    category: 'Развлечения',
+    members: [
+      { _id: 'm19', name: 'Оксана Литвинова', email: 'oksana@example.com' },
+      { _id: 'm20', name: 'Андрей Чернов', email: 'andrey@example.com' },
+      { _id: 'm21', name: 'Дарья Власова', email: 'daria@example.com' }
+    ],
+    createdAt: '2021-11-18T16:05:00.000Z'
+  },
+  {
+    _id: '8',
+    name: 'Robotics Lab',
+    description: 'Команда инженеров и разработчиков, создающих роботов и участвующая в соревнованиях.',
+    category: 'IT',
+    members: [
+      { _id: 'm22', name: 'Степан Ларионов', email: 'stepan@example.com' },
+      { _id: 'm23', name: 'Инна Полякова', email: 'inna@example.com' },
+      { _id: 'm24', name: 'Григорий Ковалев', email: 'grigory@example.com' }
+    ],
+    createdAt: '2022-07-30T11:40:00.000Z'
+  }
+];
+
+export default clubs;

--- a/client/src/pages/ClubDetail.js
+++ b/client/src/pages/ClubDetail.js
@@ -1,84 +1,18 @@
-import React, { useState, useEffect } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
-import { useAuth } from '../context/AuthContext';
-import Chat from '../components/Chat';
-import NewsWall from '../components/NewsWall';
-import axios from 'axios';
+import React from 'react';
+import { Link, useParams } from 'react-router-dom';
+import clubs from '../data/clubs';
 
 const ClubDetail = () => {
   const { id } = useParams();
-  const { user } = useAuth();
-  const navigate = useNavigate();
-  
-  const [club, setClub] = useState(null);
-  const [loading, setLoading] = useState(true);
-  const [actionLoading, setActionLoading] = useState(false);
-  const [message, setMessage] = useState('');
-
-  useEffect(() => {
-    fetchClub();
-  }, [id]); // eslint-disable-line react-hooks/exhaustive-deps
-
-  const fetchClub = async () => {
-    try {
-      const response = await axios.get(`/api/clubs/${id}`);
-      setClub(response.data);
-    } catch (error) {
-      console.error('Ошибка при загрузке клуба:', error);
-      navigate('/clubs');
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const isUserMember = () => {
-    if (!user || !club) return false;
-    return club.members.some(member => member._id === user.id);
-  };
-
-  const isUserCreator = () => {
-    if (!user || !club) return false;
-    return club.createdBy._id === user.id;
-  };
-
-  const handleJoinLeave = async () => {
-    if (!user) {
-      navigate('/login');
-      return;
-    }
-
-    setActionLoading(true);
-    setMessage('');
-
-    try {
-      const endpoint = isUserMember() ? 'leave' : 'join';
-      const response = await axios.post(`/api/clubs/${id}/${endpoint}`);
-      
-      setMessage(response.data.message);
-      // Обновляем данные клуба
-      await fetchClub();
-    } catch (error) {
-      setMessage(error.response?.data?.message || 'Произошла ошибка');
-    } finally {
-      setActionLoading(false);
-    }
-  };
-
-  if (loading) {
-    return (
-      <div className="loading">
-        <div className="spinner"></div>
-      </div>
-    );
-  }
+  const club = clubs.find((item) => item._id === id);
 
   if (!club) {
     return (
       <div className="container" style={{ padding: '40px 0', textAlign: 'center' }}>
         <h2>Клуб не найден</h2>
-        <button onClick={() => navigate('/clubs')} className="btn btn-primary">
-          Вернуться к клубам
-        </button>
+        <Link to="/clubs" className="btn btn-primary">
+          Вернуться к списку клубов
+        </Link>
       </div>
     );
   }
@@ -108,83 +42,16 @@ const ClubDetail = () => {
             </div>
           </div>
 
-          {message && (
-            <div className={`alert ${message.includes('успешно') ? 'alert-success' : 'alert-error'}`}>
-              {message}
-            </div>
-          )}
-
-          <div style={{ marginTop: '24px', display: 'flex', gap: '12px', flexWrap: 'wrap' }}>
-            {user ? (
-              <>
-                <button
-                  onClick={handleJoinLeave}
-                  disabled={actionLoading}
-                  className={`btn ${isUserMember() ? 'btn-danger' : 'btn-primary'}`}
-                >
-                  {actionLoading 
-                    ? 'Загрузка...' 
-                    : isUserMember() 
-                      ? 'Покинуть клуб' 
-                      : 'Вступить в клуб'
-                  }
-                </button>
-                {isUserCreator() && (
-                  <button
-                    onClick={() => navigate(`/clubs/${id}/edit`)}
-                    className="btn btn-outline"
-                  >
-                    Редактировать клуб
-                  </button>
-                )}
-              </>
-            ) : (
-              <button
-                onClick={() => navigate('/login')}
-                className="btn btn-primary"
-              >
-                Войти для участия
-              </button>
-            )}
+          <div style={{ marginTop: '24px', background: '#f8fafc', padding: '16px 20px', borderRadius: '12px', color: '#475569' }}>
+            Информация о вступлении и внутренних активностях клуба предоставляется на официальных мероприятиях или через представителей клуба.
           </div>
         </div>
 
-        {/* Members Section */}
-        <div className="members-section">
-          <h2>Участники клуба ({club.members.length})</h2>
-          
-          {club.members.length === 0 ? (
-            <p style={{ textAlign: 'center', padding: '40px 0', color: '#64748b' }}>
-              В клубе пока нет участников
-            </p>
-          ) : (
-            <div className="members-grid">
-              {club.members.map((member) => (
-                <div key={member._id} className="member-card">
-                  <div className="member-avatar">
-                    {member.name.charAt(0).toUpperCase()}
-                  </div>
-                  <div>
-                    <div style={{ fontWeight: '500' }}>{member.name}</div>
-                    <div style={{ fontSize: '12px', color: '#64748b' }}>
-                      {member.email}
-                    </div>
-                  </div>
-                </div>
-              ))}
-            </div>
-          )}
+        <div style={{ marginTop: '32px' }}>
+          <Link to="/clubs" className="btn btn-outline">
+            Вернуться ко всем клубам
+          </Link>
         </div>
-
-        {/* News Wall Section */}
-        {user && isUserMember() && (
-          <NewsWall clubId={id} />
-        )}
-
-        {/* Chat Section */}
-        {user && isUserMember() && (
-          <Chat clubId={id} />
-        )}
       </div>
     </div>
   );

--- a/client/src/pages/Clubs.js
+++ b/client/src/pages/Clubs.js
@@ -1,14 +1,10 @@
-import React, { useState, useEffect } from 'react';
+import React, { useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
-import { useAuth } from '../context/AuthContext';
-import axios from 'axios';
+import clubs from '../data/clubs';
 
 const Clubs = () => {
-  const { user } = useAuth();
-  const [clubs, setClubs] = useState([]);
-  const [filteredClubs, setFilteredClubs] = useState([]);
   const [selectedCategory, setSelectedCategory] = useState('all');
-  const [loading, setLoading] = useState(true);
+  const [searchTerm, setSearchTerm] = useState('');
 
   const categories = [
     { value: 'all', label: 'Все клубы' },
@@ -19,35 +15,26 @@ const Clubs = () => {
     { value: 'Развлечения', label: 'Развлечения' }
   ];
 
-  useEffect(() => {
-    fetchClubs();
-  }, []);
+  const normalizedSearch = searchTerm.trim().toLowerCase();
 
-  useEffect(() => {
-    filterClubs();
-  }, [clubs, selectedCategory]); // eslint-disable-line react-hooks/exhaustive-deps
+  const filteredClubs = useMemo(() => {
+    return clubs.filter((club) => {
+      const matchesCategory = selectedCategory === 'all' || club.category === selectedCategory;
+      const matchesSearch =
+        normalizedSearch.length === 0 ||
+        club.name.toLowerCase().includes(normalizedSearch) ||
+        club.description.toLowerCase().includes(normalizedSearch);
 
-  const fetchClubs = async () => {
-    try {
-      const response = await axios.get('/api/clubs');
-      setClubs(response.data);
-    } catch (error) {
-      console.error('Ошибка при загрузке клубов:', error);
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const filterClubs = () => {
-    if (selectedCategory === 'all') {
-      setFilteredClubs(clubs);
-    } else {
-      setFilteredClubs(clubs.filter(club => club.category === selectedCategory));
-    }
-  };
+      return matchesCategory && matchesSearch;
+    });
+  }, [selectedCategory, normalizedSearch]);
 
   const handleCategoryChange = (category) => {
     setSelectedCategory(category);
+  };
+
+  const handleSearchChange = (event) => {
+    setSearchTerm(event.target.value);
   };
 
   return (
@@ -55,13 +42,21 @@ const Clubs = () => {
       {/* Filter Section */}
       <section className="filter-section">
         <div className="container">
-          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '32px' }}>
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '32px', gap: '16px', flexWrap: 'wrap' }}>
             <h2 className="section-title" style={{ margin: 0 }}>Каталог клубов</h2>
-            {user && (
-              <Link to="/create-club" className="btn btn-primary">
-                Создать клуб
-              </Link>
-            )}
+            <div style={{ position: 'relative', flex: '1 1 280px', maxWidth: '360px' }}>
+              <input
+                type="text"
+                value={searchTerm}
+                onChange={handleSearchChange}
+                placeholder="Поиск по названию или описанию"
+                className="input"
+                style={{ width: '100%', paddingRight: '40px' }}
+              />
+              <span style={{ position: 'absolute', right: '12px', top: '50%', transform: 'translateY(-50%)', color: '#94a3b8' }}>
+                🔍
+              </span>
+            </div>
           </div>
           <div className="filter-tabs">
             {categories.map((category) => (
@@ -80,38 +75,30 @@ const Clubs = () => {
       {/* Clubs Grid */}
       <section style={{ padding: '40px 0' }}>
         <div className="container">
-          {loading ? (
-            <div className="loading">
-              <div className="spinner"></div>
+          {filteredClubs.length === 0 ? (
+            <div style={{ textAlign: 'center', padding: '60px 0' }}>
+              <h3>Клубы не найдены</h3>
+              <p>Попробуйте изменить поисковый запрос или категорию.</p>
             </div>
           ) : (
-            <>
-              {filteredClubs.length === 0 ? (
-                <div style={{ textAlign: 'center', padding: '60px 0' }}>
-                  <h3>Клубы не найдены</h3>
-                  <p>Попробуйте выбрать другую категорию</p>
+            <div className="clubs-grid">
+              {filteredClubs.map((club) => (
+                <div key={club._id} className="club-card">
+                  <div className="club-category">{club.category}</div>
+                  <h3 className="club-name">{club.name}</h3>
+                  <p className="club-description">{club.description}</p>
+                  <div className="club-members">
+                    Участников: {club.members.length}
+                  </div>
+                  <Link
+                    to={`/clubs/${club._id}`}
+                    className="btn btn-outline"
+                  >
+                    Подробнее
+                  </Link>
                 </div>
-              ) : (
-                <div className="clubs-grid">
-                  {filteredClubs.map((club) => (
-                    <div key={club._id} className="club-card">
-                      <div className="club-category">{club.category}</div>
-                      <h3 className="club-name">{club.name}</h3>
-                      <p className="club-description">{club.description}</p>
-                      <div className="club-members">
-                        Участников: {club.members.length}
-                      </div>
-                      <Link 
-                        to={`/clubs/${club._id}`} 
-                        className="btn btn-outline"
-                      >
-                        Подробнее
-                      </Link>
-                    </div>
-                  ))}
-                </div>
-              )}
-            </>
+              ))}
+            </div>
           )}
         </div>
       </section>

--- a/client/src/pages/Home.js
+++ b/client/src/pages/Home.js
@@ -1,28 +1,9 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import { Link } from 'react-router-dom';
-import { useAuth } from '../context/AuthContext';
-import axios from 'axios';
+import clubs from '../data/clubs';
 
 const Home = () => {
-  const { user } = useAuth();
-  const [popularClubs, setPopularClubs] = useState([]);
-  const [loading, setLoading] = useState(true);
-
-  useEffect(() => {
-    fetchPopularClubs();
-  }, []);
-
-  const fetchPopularClubs = async () => {
-    try {
-      const response = await axios.get('/api/clubs');
-      // Берем первые 6 клубов как популярные
-      setPopularClubs(response.data.slice(0, 6));
-    } catch (error) {
-      console.error('Ошибка при загрузке клубов:', error);
-    } finally {
-      setLoading(false);
-    }
-  };
+  const popularClubs = clubs.slice(0, 6);
 
   return (
     <div>
@@ -35,20 +16,12 @@ const Home = () => {
             и находите новых друзей в университете
           </p>
           <div className="hero-actions">
-            {user ? (
-              <Link to="/clubs" className="btn btn-primary btn-lg">
-                Посмотреть клубы
-              </Link>
-            ) : (
-              <>
-                <Link to="/register" className="btn btn-primary btn-lg">
-                  Зарегистрироваться
-                </Link>
-                <Link to="/login" className="btn btn-outline btn-lg">
-                  Войти
-                </Link>
-              </>
-            )}
+            <Link to="/clubs" className="btn btn-primary btn-lg">
+              Посмотреть клубы
+            </Link>
+            <Link to="/register" className="btn btn-outline btn-lg">
+              Регистрация
+            </Link>
           </div>
         </div>
       </section>
@@ -58,30 +31,24 @@ const Home = () => {
         <div className="container">
           <h2 className="section-title">Популярные клубы</h2>
           
-          {loading ? (
-            <div className="loading">
-              <div className="spinner"></div>
-            </div>
-          ) : (
-            <div className="clubs-grid">
-              {popularClubs.map((club) => (
-                <div key={club._id} className="club-card">
-                  <div className="club-category">{club.category}</div>
-                  <h3 className="club-name">{club.name}</h3>
-                  <p className="club-description">{club.description}</p>
-                  <div className="club-members">
-                    Участников: {club.members.length}
-                  </div>
-                  <Link 
-                    to={`/clubs/${club._id}`} 
-                    className="btn btn-outline"
-                  >
-                    Подробнее
-                  </Link>
+          <div className="clubs-grid">
+            {popularClubs.map((club) => (
+              <div key={club._id} className="club-card">
+                <div className="club-category">{club.category}</div>
+                <h3 className="club-name">{club.name}</h3>
+                <p className="club-description">{club.description}</p>
+                <div className="club-members">
+                  Участников: {club.members.length}
                 </div>
-              ))}
-            </div>
-          )}
+                <Link
+                  to={`/clubs/${club._id}`}
+                  className="btn btn-outline"
+                >
+                  Подробнее
+                </Link>
+              </div>
+            ))}
+          </div>
           
           <div style={{ textAlign: 'center', marginTop: '40px' }}>
             <Link to="/clubs" className="btn btn-primary">


### PR DESCRIPTION
## Summary
- add a static club dataset and reuse it on public pages
- refactor Home, Clubs and ClubDetail to remove API/auth dependencies and show public details only
- simplify ClubDetail interactions to avoid mutations while keeping navigation helpers

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db9bc0d1388329a8dda2c894b0992c