### PR TITLE
Resolve public club pages after merge

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -2,42 +2,23 @@ import React from 'react';
 import { Routes, Route } from 'react-router-dom';
 import Navbar from './components/Navbar';
 import Home from './pages/Home';
-import Login from './pages/Login';
-import Register from './pages/Register';
 import Clubs from './pages/Clubs';
 import ClubDetail from './pages/ClubDetail';
-import CreateClub from './pages/CreateClub';
-import EditClub from './pages/EditClub';
-import Profile from './pages/Profile';
-import { AuthProvider } from './context/AuthContext';
 import './App.css';
 
-function AppContent() {
+function App() {
   return (
     <div className="App">
       <Navbar />
       <main>
         <Routes>
           <Route path="/" element={<Home />} />
-          <Route path="/login" element={<Login />} />
-          <Route path="/register" element={<Register />} />
           <Route path="/clubs" element={<Clubs />} />
           <Route path="/clubs/:id" element={<ClubDetail />} />
-          <Route path="/create-club" element={<CreateClub />} />
-          <Route path="/clubs/:id/edit" element={<EditClub />} />
-          <Route path="/profile" element={<Profile />} />
           <Route path="*" element={<Home />} />
         </Routes>
       </main>
     </div>
-  );
-}
-
-function App() {
-  return (
-    <AuthProvider>
-      <AppContent />
-    </AuthProvider>
   );
 }
 

--- a/client/src/pages/ClubDetail.js
+++ b/client/src/pages/ClubDetail.js
@@ -1,17 +1,44 @@
-import React from 'react';
-import { Link, useParams } from 'react-router-dom';
-import clubs from '../data/clubs';
+import React, { useState, useEffect } from 'react';
+import { Link, useNavigate, useParams } from 'react-router-dom';
+import axios from 'axios';
 
 const ClubDetail = () => {
   const { id } = useParams();
-  const club = clubs.find((item) => item._id === id);
+  const navigate = useNavigate();
+
+  const [club, setClub] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchClub = async () => {
+      try {
+        const response = await axios.get(`/api/clubs/${id}`);
+        setClub(response.data);
+      } catch (error) {
+        console.error('Ошибка при загрузке клуба:', error);
+        navigate('/clubs');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchClub();
+  }, [id, navigate]);
+
+  if (loading) {
+    return (
+      <div className="loading">
+        <div className="spinner"></div>
+      </div>
+    );
+  }
 
   if (!club) {
     return (
       <div className="container" style={{ padding: '40px 0', textAlign: 'center' }}>
         <h2>Клуб не найден</h2>
         <Link to="/clubs" className="btn btn-primary">
-          Вернуться к списку клубов
+          Вернуться к клубам
         </Link>
       </div>
     );
@@ -20,11 +47,10 @@ const ClubDetail = () => {
   return (
     <div className="club-detail">
       <div className="container">
-        {/* Club Header */}
         <div className="club-header">
           <h1 className="club-title">{club.name}</h1>
           <div className="club-category">{club.category}</div>
-          
+
           <div className="club-meta">
             <p>{club.description}</p>
           </div>
@@ -42,8 +68,17 @@ const ClubDetail = () => {
             </div>
           </div>
 
-          <div style={{ marginTop: '24px', background: '#f8fafc', padding: '16px 20px', borderRadius: '12px', color: '#475569' }}>
-            Информация о вступлении и внутренних активностях клуба предоставляется на официальных мероприятиях или через представителей клуба.
+          <div
+            style={{
+              marginTop: '24px',
+              background: '#f8fafc',
+              padding: '16px 20px',
+              borderRadius: '12px',
+              color: '#475569',
+            }}
+          >
+            Информация о вступлении и внутренних активностях клуба предоставляется
+            на официальных мероприятиях или через представителей клуба.
           </div>
         </div>
 

--- a/client/src/pages/Clubs.js
+++ b/client/src/pages/Clubs.js
@@ -1,10 +1,12 @@
-import React, { useMemo, useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
-import clubs from '../data/clubs';
+import axios from 'axios';
 
 const Clubs = () => {
+  const [clubs, setClubs] = useState([]);
+  const [filteredClubs, setFilteredClubs] = useState([]);
   const [selectedCategory, setSelectedCategory] = useState('all');
-  const [searchTerm, setSearchTerm] = useState('');
+  const [loading, setLoading] = useState(true);
 
   const categories = [
     { value: 'all', label: 'Все клубы' },
@@ -12,51 +14,51 @@ const Clubs = () => {
     { value: 'Культура', label: 'Культура' },
     { value: 'IT', label: 'IT' },
     { value: 'Творчество', label: 'Творчество' },
-    { value: 'Развлечения', label: 'Развлечения' }
+    { value: 'Развлечения', label: 'Развлечения' },
   ];
 
-  const normalizedSearch = searchTerm.trim().toLowerCase();
+  useEffect(() => {
+    const fetchClubs = async () => {
+      try {
+        const response = await axios.get('/api/clubs');
+        setClubs(response.data);
+      } catch (error) {
+        console.error('Ошибка при загрузке клубов:', error);
+      } finally {
+        setLoading(false);
+      }
+    };
 
-  const filteredClubs = useMemo(() => {
-    return clubs.filter((club) => {
-      const matchesCategory = selectedCategory === 'all' || club.category === selectedCategory;
-      const matchesSearch =
-        normalizedSearch.length === 0 ||
-        club.name.toLowerCase().includes(normalizedSearch) ||
-        club.description.toLowerCase().includes(normalizedSearch);
+    fetchClubs();
+  }, []);
 
-      return matchesCategory && matchesSearch;
-    });
-  }, [selectedCategory, normalizedSearch]);
+  useEffect(() => {
+    if (selectedCategory === 'all') {
+      setFilteredClubs(clubs);
+    } else {
+      setFilteredClubs(clubs.filter((club) => club.category === selectedCategory));
+    }
+  }, [clubs, selectedCategory]);
 
   const handleCategoryChange = (category) => {
     setSelectedCategory(category);
   };
 
-  const handleSearchChange = (event) => {
-    setSearchTerm(event.target.value);
-  };
-
   return (
     <div>
-      {/* Filter Section */}
       <section className="filter-section">
         <div className="container">
-          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '32px', gap: '16px', flexWrap: 'wrap' }}>
-            <h2 className="section-title" style={{ margin: 0 }}>Каталог клубов</h2>
-            <div style={{ position: 'relative', flex: '1 1 280px', maxWidth: '360px' }}>
-              <input
-                type="text"
-                value={searchTerm}
-                onChange={handleSearchChange}
-                placeholder="Поиск по названию или описанию"
-                className="input"
-                style={{ width: '100%', paddingRight: '40px' }}
-              />
-              <span style={{ position: 'absolute', right: '12px', top: '50%', transform: 'translateY(-50%)', color: '#94a3b8' }}>
-                🔍
-              </span>
-            </div>
+          <div
+            style={{
+              display: 'flex',
+              justifyContent: 'space-between',
+              alignItems: 'center',
+              marginBottom: '32px',
+            }}
+          >
+            <h2 className="section-title" style={{ margin: 0 }}>
+              Каталог клубов
+            </h2>
           </div>
           <div className="filter-tabs">
             {categories.map((category) => (
@@ -72,33 +74,35 @@ const Clubs = () => {
         </div>
       </section>
 
-      {/* Clubs Grid */}
       <section style={{ padding: '40px 0' }}>
         <div className="container">
-          {filteredClubs.length === 0 ? (
-            <div style={{ textAlign: 'center', padding: '60px 0' }}>
-              <h3>Клубы не найдены</h3>
-              <p>Попробуйте изменить поисковый запрос или категорию.</p>
+          {loading ? (
+            <div className="loading">
+              <div className="spinner"></div>
             </div>
           ) : (
-            <div className="clubs-grid">
-              {filteredClubs.map((club) => (
-                <div key={club._id} className="club-card">
-                  <div className="club-category">{club.category}</div>
-                  <h3 className="club-name">{club.name}</h3>
-                  <p className="club-description">{club.description}</p>
-                  <div className="club-members">
-                    Участников: {club.members.length}
-                  </div>
-                  <Link
-                    to={`/clubs/${club._id}`}
-                    className="btn btn-outline"
-                  >
-                    Подробнее
-                  </Link>
+            <>
+              {filteredClubs.length === 0 ? (
+                <div style={{ textAlign: 'center', padding: '60px 0' }}>
+                  <h3>Клубы не найдены</h3>
+                  <p>Попробуйте выбрать другую категорию</p>
                 </div>
-              ))}
-            </div>
+              ) : (
+                <div className="clubs-grid">
+                  {filteredClubs.map((club) => (
+                    <div key={club._id} className="club-card">
+                      <div className="club-category">{club.category}</div>
+                      <h3 className="club-name">{club.name}</h3>
+                      <p className="club-description">{club.description}</p>
+                      <div className="club-members">Участников: {club.members.length}</div>
+                      <Link to={`/clubs/${club._id}`} className="btn btn-outline">
+                        Подробнее
+                      </Link>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </>
           )}
         </div>
       </section>

--- a/client/src/pages/Home.js
+++ b/client/src/pages/Home.js
@@ -1,55 +1,67 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
-import clubs from '../data/clubs';
+import axios from 'axios';
 
 const Home = () => {
-  const popularClubs = clubs.slice(0, 6);
+  const [popularClubs, setPopularClubs] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchPopularClubs = async () => {
+      try {
+        const response = await axios.get('/api/clubs');
+        setPopularClubs(response.data.slice(0, 6));
+      } catch (error) {
+        console.error('Ошибка при загрузке клубов:', error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchPopularClubs();
+  }, []);
 
   return (
     <div>
-      {/* Hero Section */}
       <section className="hero">
         <div className="container">
           <h1>Университетские клубы интересов</h1>
           <p>
-            Присоединяйтесь к сообществам единомышленников, развивайте свои интересы 
+            Присоединяйтесь к сообществам единомышленников, развивайте свои интересы
             и находите новых друзей в университете
           </p>
           <div className="hero-actions">
             <Link to="/clubs" className="btn btn-primary btn-lg">
               Посмотреть клубы
             </Link>
-            <Link to="/register" className="btn btn-outline btn-lg">
-              Регистрация
-            </Link>
           </div>
         </div>
       </section>
 
-      {/* Popular Clubs Section */}
       <section className="popular-clubs">
         <div className="container">
           <h2 className="section-title">Популярные клубы</h2>
-          
-          <div className="clubs-grid">
-            {popularClubs.map((club) => (
-              <div key={club._id} className="club-card">
-                <div className="club-category">{club.category}</div>
-                <h3 className="club-name">{club.name}</h3>
-                <p className="club-description">{club.description}</p>
-                <div className="club-members">
-                  Участников: {club.members.length}
+
+          {loading ? (
+            <div className="loading">
+              <div className="spinner"></div>
+            </div>
+          ) : (
+            <div className="clubs-grid">
+              {popularClubs.map((club) => (
+                <div key={club._id} className="club-card">
+                  <div className="club-category">{club.category}</div>
+                  <h3 className="club-name">{club.name}</h3>
+                  <p className="club-description">{club.description}</p>
+                  <div className="club-members">Участников: {club.members.length}</div>
+                  <Link to={`/clubs/${club._id}`} className="btn btn-outline">
+                    Подробнее
+                  </Link>
                 </div>
-                <Link
-                  to={`/clubs/${club._id}`}
-                  className="btn btn-outline"
-                >
-                  Подробнее
-                </Link>
-              </div>
-            ))}
-          </div>
-          
+              ))}
+            </div>
+          )}
+
           <div style={{ textAlign: 'center', marginTop: '40px' }}>
             <Link to="/clubs" className="btn btn-primary">
               Посмотреть все клубы


### PR DESCRIPTION
## Summary
- simplify the client router to only expose the home and club pages
- restore Axios-powered data loading for the home, clubs list, and club detail views without static data

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dba74454c88329a44ef442768fdd1f