### PR TITLE
Add analytics counters to public index page

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -18,7 +18,7 @@
     <noscript>Вам необходимо включить JavaScript для работы этого приложения.</noscript>
     <div id="root"></div>
     <!--LiveInternet counter--><a href="https://www.liveinternet.ru/click"
-target="_blank"><img id="licntD8A3" width="88" height="31" style="border:0" 
+target="_blank"><img id="licntD8A3" width="88" height="31" style="border:0"
 title="LiveInternet: показано число просмотров и посетителей за 24 часа"
 src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAEALAAAAAABAAEAAAIBTAA7"
 alt=""/></a><script>(function(d,s){d.getElementById("licntD8A3").src=
@@ -27,6 +27,73 @@ alt=""/></a><script>(function(d,s){d.getElementById("licntD8A3").src=
 (s.colorDepth?s.colorDepth:s.pixelDepth))+";u"+escape(d.URL)+
 ";h"+escape(d.title.substring(0,150))+";"+Math.random()})
 (document,screen)</script><!--/LiveInternet-->
+
+    <!-- Top.Mail.Ru counter -->
+    <script type="text/javascript">
+      var _tmr = window._tmr || (window._tmr = []);
+      _tmr.push({ id: "3704031", type: "pageView", start: new Date().getTime() });
+      (function (d, w, id) {
+        if (d.getElementById(id)) return;
+        var ts = d.createElement("script");
+        ts.type = "text/javascript";
+        ts.async = true;
+        ts.id = id;
+        ts.src = "https://top-fwz1.mail.ru/js/code.js";
+        var f = function () {
+          var s = d.getElementsByTagName("script")[0];
+          s.parentNode.insertBefore(ts, s);
+        };
+        if (w.opera == "[object Opera]") {
+          d.addEventListener("DOMContentLoaded", f, false);
+        } else {
+          f();
+        }
+      })(document, window, "tmr-code");
+    </script>
+    <noscript>
+      <div>
+        <img
+          src="https://top-fwz1.mail.ru/counter?id=3704031;js=na"
+          style="position: absolute; left: -9999px;"
+          alt="Top.Mail.Ru"
+        />
+      </div>
+    </noscript>
+    <!-- /Top.Mail.Ru counter -->
+
+    <!-- Top100 (Kraken) Counter -->
+    <script>
+      (function (w, d, c) {
+        (w[c] = w[c] || []).push(function () {
+          var options = {
+            project: 7749163,
+          };
+          try {
+            w.top100Counter = new top100(options);
+          } catch (e) {}
+        });
+        var n = d.getElementsByTagName("script")[0],
+          s = d.createElement("script"),
+          f = function () {
+            n.parentNode.insertBefore(s, n);
+          };
+        s.type = "text/javascript";
+        s.async = true;
+        s.src =
+          (d.location.protocol == "https:" ? "https:" : "http:") +
+          "//st.top100.ru/top100/top100.js";
+
+        if (w.opera == "[object Opera]") {
+          d.addEventListener("DOMContentLoaded", f, false);
+        } else {
+          f();
+        }
+      })(window, document, "_top100q");
+    </script>
+    <noscript>
+      <img src="//counter.rambler.ru/top100.cnt?pid=7749163" alt="Топ-100" />
+    </noscript>
+    <!-- END Top100 (Kraken) Counter -->
 
   </body>
 </html>


### PR DESCRIPTION
## Summary
- embed the Top.Mail.Ru counter script into the public index template
- add the Top100 (Kraken) counter snippet to track site analytics

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd4d4d41748329bb8526ee88d69b5c